### PR TITLE
Swap to paper-plugin

### DIFF
--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     compileOnly("com.nexomc:nexo:0.7.0")
     compileOnly("com.github.retrooper:packetevents-spigot:2.7.0")
     compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.4.0-SNAPSHOT")
-    implementation("co.aikar:acf-paper:0.5.1-SNAPSHOT")
+    compileOnly("co.aikar:acf-paper:0.5.1-SNAPSHOT")
     implementation(project(":nms"))
     implementation(project(path = ":v1_20", configuration = "reobf"))
     implementation(project(path = ":v1_20_3", configuration = "reobf"))
@@ -57,8 +57,6 @@ tasks {
 
     shadowJar {
         mergeServiceFiles()
-        relocate("co.aikar.commands", "com.hibiscusmc.hmcleaves.paper.acf")
-        relocate("co.aikar.locales", "com.hibiscusmc.hmcleaves.paper.locales")
 
         archiveFileName.set("hmcleaves-${project.version}.jar")
 

--- a/spigot/build.gradle.kts
+++ b/spigot/build.gradle.kts
@@ -23,7 +23,7 @@ repositories {
 dependencies {
     implementation("org.jetbrains:annotations:24.0.0")
     compileOnly("io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT")
-    compileOnly("com.nexomc:nexo:0.7.0")
+    compileOnly("com.nexomc:nexo:1.6.0")
     compileOnly("com.github.retrooper:packetevents-spigot:2.7.0")
     compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.4.0-SNAPSHOT")
     compileOnly("co.aikar:acf-paper:0.5.1-SNAPSHOT")

--- a/spigot/src/main/java/com/hibiscusmc/hmcleaves/paper/HMCLeavesLoader.java
+++ b/spigot/src/main/java/com/hibiscusmc/hmcleaves/paper/HMCLeavesLoader.java
@@ -25,5 +25,3 @@ public class HMCLeavesLoader implements PluginLoader {
         pluginClasspathBuilder.addLibrary(resolver);
     }
 }
-
-record Repo(String id, String url) {}

--- a/spigot/src/main/java/com/hibiscusmc/hmcleaves/paper/HMCLeavesLoader.java
+++ b/spigot/src/main/java/com/hibiscusmc/hmcleaves/paper/HMCLeavesLoader.java
@@ -1,0 +1,29 @@
+package com.hibiscusmc.hmcleaves.paper;
+
+import io.papermc.paper.plugin.loader.PluginClasspathBuilder;
+import io.papermc.paper.plugin.loader.PluginLoader;
+import io.papermc.paper.plugin.loader.library.impl.MavenLibraryResolver;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.jetbrains.annotations.NotNull;
+
+public class HMCLeavesLoader implements PluginLoader {
+    @Override
+    public void classloader(@NotNull PluginClasspathBuilder pluginClasspathBuilder) {
+
+        MavenLibraryResolver resolver = new MavenLibraryResolver();
+
+        resolver.addRepository(new RemoteRepository.Builder(
+                "aikar",
+                "default",
+                "https://repo.aikar.co/content/groups/aikar/"
+        ).build());
+
+        resolver.addDependency(new Dependency(new DefaultArtifact("co.aikar:acf-paper:0.5.1-SNAPSHOT"), null));
+
+        pluginClasspathBuilder.addLibrary(resolver);
+    }
+}
+
+record Repo(String id, String url) {}

--- a/spigot/src/main/resources/paper-plugin.yml
+++ b/spigot/src/main/resources/paper-plugin.yml
@@ -1,10 +1,9 @@
 name: HMCLeaves
 version: "3.0.0-SNAPSHOT"
 main: com.hibiscusmc.hmcleaves.paper.HMCLeaves
-depend: [ packetevents ]
-softdepend: [ Nexo, WorldEdit ]
-api-version: 1.20
+api-version: "1.20"
 load: STARTUP
+loader: com.hibiscusmc.hmcleaves.paper.HMCLeavesLoader
 permissions:
   "hmcleaves.command.transformschematic":
     description: Allows the player to use the /transformschematic command
@@ -18,3 +17,14 @@ permissions:
   "hmcleaves.placedecayable":
     description: Allows the player to place decayable leaves
     default: op
+dependencies:
+  server:
+    packetevents:
+      load: BEFORE
+      required: true
+    Nexo:
+      load: BEFORE
+      required: false
+    WorldEdit:
+      load: BEFORE
+      required: false


### PR DESCRIPTION
Make a Paper PluginLoader class
Bump Nexo to 1.6.0
`implementation` -> `compileOnly` for acf-paper (handled in HMCleavesLoader)
brings down filesize and shows up as a paper plugin (very cool)