### PR TITLE
Small fix - Block dropping

### DIFF
--- a/paper/src/main/java/com/hibiscusmc/hmcleaves/paper/breaking/BlockBreakManager.java
+++ b/paper/src/main/java/com/hibiscusmc/hmcleaves/paper/breaking/BlockBreakManager.java
@@ -143,7 +143,7 @@ public final class BlockBreakManager {
         if (drops != null) {
             final ItemStack drop = drops.copyLeavesItem();
             if (drop != null) {
-                world.dropItemNaturally(location, drop);
+                world.dropItemNaturally(location.toCenterLocation(), drop);
             }
         }
     }

--- a/paper/src/main/java/com/hibiscusmc/hmcleaves/paper/listener/BlockBreakListener.java
+++ b/paper/src/main/java/com/hibiscusmc/hmcleaves/paper/listener/BlockBreakListener.java
@@ -60,7 +60,7 @@ public final class BlockBreakListener extends CustomBlockListener {
                 return;
             }
             final World world = block.getWorld();
-            Bukkit.getScheduler().runTaskLater(this.plugin, () -> world.dropItemNaturally(location.clone(), dropItem), 1);
+            Bukkit.getScheduler().runTaskLater(this.plugin, () -> world.dropItemNaturally(location.clone().toCenterLocation(), dropItem), 1);
         });
     }
 


### PR DESCRIPTION
When breaking an HMCLeaves block, it drops the item on the NW bottom corner rather than the center of the block which causes the item to go through walls sometimes
This simple change fixes it